### PR TITLE
fix(deps): patch GitHub security alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,9 +1187,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1400,9 +1400,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",


### PR DESCRIPTION
## Summary
- Refresh lockfile entries for GitHub security alert remediation.
- Keep the change scoped to the dependency lockfile only.

## Lockfile rationale
This is an intentional lockfile-only security update. The manifest constraints already allow the patched versions, and the lockfile is the surface GitHub's dependency graph is alerting on.

Residual note: full integration lifecycle tests hang/fail in the local temp environment, but cargo check --all-targets and cargo test --lib pass for this lockfile-only update.

## Verification
- Local dependency update completed from fresh main clone.
- `cargo check --all-targets` passed.
- `cargo test --lib` passed, 25 tests.