### PR TITLE
chore(deps): refresh uuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,9 +2321,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",


### PR DESCRIPTION
## Summary
- Refreshes the locked `uuid` crate from 1.22.0 to 1.23.0.
- Replaces the stale Dependabot branch with a policy-compliant Codex branch.
- Keeps the change scoped to `Cargo.lock`.

## Verification
- `cargo check --all-targets`
- `cargo test --lib`
